### PR TITLE
Use HTTPS URL for Maven repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         jcenter()
-        maven { url 'http://repo1.maven.org/maven2' }
+        maven { url 'https://repo1.maven.org/maven2' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'


### PR DESCRIPTION
Plain HTTP [is insecure](https://max.computer/blog/how-to-take-over-the-computer-of-any-java-or-clojure-or-scala-developer/).