### PR TITLE
Don't abort build on linting errors (fixes #5)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,10 @@ android {
         targetSdkVersion 25
     }
 
+    lintOptions {
+        abortOnError false
+    }
+
     buildTypes {
         release {
             minifyEnabled true


### PR DESCRIPTION
This would make the F-Droid build recipe cleaner.