### PR TITLE
Add Google repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
         maven { url 'https://repo1.maven.org/maven2' }
     }
     dependencies {
@@ -13,6 +14,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 


### PR DESCRIPTION
This patch fixes the following error with recent Android build tools:
```
A problem occurred configuring root project 'FairphoneLauncher3'.
> Could not resolve all files for configuration ':classpath'.
   > Could not find com.android.tools.build:gradle:3.1.2.
     Searched in the following locations:
         https://jcenter.bintray.com/com/android/tools/build/gradle/3.1.2/gradle-3.1.2.pom
         https://jcenter.bintray.com/com/android/tools/build/gradle/3.1.2/gradle-3.1.2.jar
         https://repo1.maven.org/maven2/com/android/tools/build/gradle/3.1.2/gradle-3.1.2.pom
         https://repo1.maven.org/maven2/com/android/tools/build/gradle/3.1.2/gradle-3.1.2.jar
     Required by:
         project :
```