### PR TITLE
Restore default screen

### DIFF
--- a/res/xml/default_workspace_4x4.xml
+++ b/res/xml/default_workspace_4x4.xml
@@ -40,6 +40,9 @@
         launcher:y="4"
         launcher:title="@string/google_title">
         <favorite
+            launcher:packageName="com.android.vending"
+            launcher:className="com.android.vending.AssetBrowserActivity" />
+        <favorite
             launcher:className="com.google.android.googlequicksearchbox.SearchActivity"
             launcher:packageName="com.google.android.googlequicksearchbox" />
         <favorite
@@ -89,8 +92,8 @@
         launcher:y="4" />
 
     <favorite
-        launcher:packageName="com.android.vending"
-        launcher:className="com.android.vending.AssetBrowserActivity"
+        launcher:packageName="org.fdroid.fdroid"
+        launcher:className="org.fdroid.fdroid.views.main.MainActivity"
         launcher:screen="2"
         launcher:x="3"
         launcher:y="4" />

--- a/res/xml/default_workspace_4x4.xml
+++ b/res/xml/default_workspace_4x4.xml
@@ -17,7 +17,7 @@
 <favorites xmlns:launcher="http://schemas.android.com/apk/res-auto/com.android.launcher3">
 
     <appwidget
-        launcher:packageName="com.fairphone.mycontacts"
+        launcher:packageName="community.fairphone.mycontacts"
         launcher:className="com.fairphone.mycontacts.widget.PeopleWidget"
         launcher:screen="1"
         launcher:x="0"

--- a/res/xml/default_workspace_4x4.xml
+++ b/res/xml/default_workspace_4x4.xml
@@ -96,7 +96,7 @@
         launcher:y="4" />
 
     <appwidget
-        launcher:packageName="com.fairphone.fplauncher3"
+        launcher:packageName="community.fairphone.fplauncher3"
         launcher:className="com.fairphone.fplauncher3.widgets.appswitcher.AppSwitcherWidget"
         launcher:screen="3"
         launcher:x="0"


### PR DESCRIPTION
This restores the default workspace (widgets and app launch icons) the Fairphone Launcher 3 came with.

The only difference is the Google Play launcher is now inside the Google folder and a F-Droid launcher is shown in its place, because our main distribution channel is F-Droid, not Google Play. This also solves the weird empty screen users without Google Mobile Services (a.k.a. GApps) installed felt in the first launch.

Also a related question: should we replace the Google Search widget with the Fairphone Clock widget?